### PR TITLE
fix: ajustar layout da tabela e remover coluna de unidade do conselho regulador

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -465,9 +465,7 @@ tbody td {
 
 tbody tr:last-child td { border-bottom: 0; }
 tbody tr:hover td { background: var(--table-row-hover); }
-.num { width: 64px; }
-#processTable td.num,
-#processTable td.unidade { text-align: center; }
+#processTable td.num { text-align: center; }
 .small { color: var(--muted); font-size: var(--text-sm); }
 .text-danger { color: var(--danger); }
 
@@ -486,21 +484,20 @@ tbody tr:hover td { background: var(--table-row-hover); }
   #processTable { min-width: 1040px; }
 
   #processTable th:nth-child(1),
-  #processTable td:nth-child(1) { width: 7%; }
+  #processTable td:nth-child(1) { width: 7%; }   /* Ordem */
   #processTable th:nth-child(2),
-  #processTable td:nth-child(2) { width: 18%; }
+  #processTable td:nth-child(2) { width: 26%; }  /* Nº Processo */
   #processTable th:nth-child(3),
-  #processTable td:nth-child(3) { width: 22%; }
+  #processTable td:nth-child(3) { width: 28%; }  /* Assunto */
+  #processTable th:nth-child(4),
+  #processTable td:nth-child(4) { width: 26%; }  /* Defesa / Recurso */
   #processTable th:nth-child(5),
-  #processTable td:nth-child(5) { width: 23%; }
-  #processTable th:nth-child(6),
-  #processTable td:nth-child(6) { width: 18%; }
-  #processTable th:nth-child(7),
-  #processTable td:nth-child(7) { width: 12%; }
+  #processTable td:nth-child(5) { width: 13%; }  /* Ações */
 }
 
 #processTable input,
 #processTable select { font-size: var(--text-md); }
+#processTable select { min-width: 130px; }
 
 /* 16px evita o zoom automático do iOS ao focar; no desktop cabe mais texto. */
 @media (pointer: fine) {
@@ -558,8 +555,28 @@ tbody tr:hover td { background: var(--table-row-hover); }
   font-size: var(--text-base);
   font-weight: 700;
 }
+#resultTable {
+  table-layout: fixed;
+}
 
-#resultTable td.sorteado-unidade { color: var(--accent); font-weight: 700; }
+#resultTable th,
+#resultTable td {
+  text-align: center;
+}
+
+#resultTable th:nth-child(1),
+#resultTable td:nth-child(1) { width: 33%; }  /* Nº Processo */
+
+#resultTable th:nth-child(2),
+#resultTable td:nth-child(2) { width: 34%; }  /* Assunto */
+
+#resultTable th:nth-child(3),
+#resultTable td:nth-child(3) { width: 33%; }  /* Sorteado Para */
+
+#resultTable td.sorteado-unidade {
+  color: var(--accent);
+  font-weight: 700;
+}
 
 /* Login e estados vazios */
 #loginScreen {
@@ -812,8 +829,7 @@ button.is-loading { display: inline-flex; align-items: center; justify-content: 
   }
 
   #processTable tbody td,
-  #processTable tbody td.num,
-  #processTable tbody td.unidade {
+  #processTable tbody td.num {
     display: grid;
     width: auto;
     gap: 6px;
@@ -837,8 +853,6 @@ button.is-loading { display: inline-flex; align-items: center; justify-content: 
     gap: 8px;
     font-weight: 700;
   }
-
-  #processTable tbody td.unidade:empty { display: none; }
 
   #processTable tbody td.acoes {
     display: flex;

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -45,7 +45,6 @@ const btnCj = document.getElementById('btnCj');
 const btnVoltar = document.getElementById('btnVoltar');
 const modeSelector = document.getElementById('modeSelector');
 const sorteadorContent = document.getElementById('sorteadorContent');
-const thUnidade = document.getElementById('thUnidade');
 const thRecurso = document.getElementById('thRecurso');
 const pillsContainer = document.getElementById('pillsContainer');
 const txtModo = document.getElementById('txtModo');
@@ -94,9 +93,8 @@ function iniciarSorteador(modo, unidades) {
   assuntosAtivos = modo === 'CREG' ? assuntosCreg : assuntosCj;
 
   btnVoltar.hidden = false;
-  txtModo.textContent = modo === 'CREG' ? 'Conselho Regulador' : 'Câmara de Julgamento';
+  txtModo.textContent = modo === 'CREG' ? 'Conselho Regulador (CREG)' : 'Câmara de Julgamento (CJ)';
 
-  thUnidade.textContent = modo === 'CREG' ? 'Unidade Conselho Regulador (CREG)' : 'Unidade Câmara de Julgamento (CJ)';
   thRecurso.textContent = modo === 'CREG' ? 'Recurso' : 'Defesa';
   sortearBtn.textContent = `Sortear ${modo} e Exportar`;
 
@@ -172,18 +170,22 @@ function createRowElement(index) {
   const optDefaultAss = document.createElement('option'); optDefaultAss.value = ''; optDefaultAss.textContent = 'Selecione o Assunto'; optDefaultAss.disabled = true; optDefaultAss.selected = true;
   selAss.appendChild(optDefaultAss);
   assuntosAtivos.forEach(a => { const o = document.createElement('option'); o.value = a; o.textContent = a; selAss.appendChild(o) });
+  const atualizarEstadoAssunto = () => selAss.classList.toggle('placeholder-select', !selAss.value);
+  atualizarEstadoAssunto();
+  selAss.addEventListener('change', atualizarEstadoAssunto);
   // Na Câmara de Julgamento o assunto é sempre Auto de Infração: já vem definido e travado.
   if (modoSorteio === 'CJ') {
     selAss.value = 'Auto de Infração';
     selAss.disabled = true;
     selAss.classList.add('fixed-field');
+    atualizarEstadoAssunto();
   }
   tdAss.appendChild(selAss);
   const tdRec = document.createElement('td');
   tdRec.className = 'col-decisao';
   tdRec.dataset.label = modoSorteio === 'CJ' ? 'Defesa' : 'Recurso';
   const selRec = document.createElement('select'); selRec.setAttribute('aria-label', `${modoSorteio === 'CJ' ? 'Defesa' : 'Recurso'}, linha ${index}`);
-  const optDefaultRec = document.createElement('option'); optDefaultRec.value = ''; optDefaultRec.textContent = modoSorteio === 'CJ' ? 'Houve defesa?' : 'Selecione o tipo de recurso'; optDefaultRec.disabled = true; optDefaultRec.selected = true;
+  const optDefaultRec = document.createElement('option'); optDefaultRec.value = ''; optDefaultRec.textContent = modoSorteio === 'CJ' ? 'Houve defesa?' : 'Selecione o Recurso'; optDefaultRec.disabled = true; optDefaultRec.selected = true;
   selRec.appendChild(optDefaultRec);
   (modoSorteio === 'CJ' ? defesas : recursos).forEach(r => { const o = document.createElement('option'); o.value = r; o.textContent = r; selRec.appendChild(o) });
   const atualizarEstadoDefesa = () => selRec.classList.toggle('placeholder-select', !selRec.value);
@@ -213,8 +215,6 @@ function createRowElement(index) {
     });
   }
 
-  const tdUn = document.createElement('td'); tdUn.className = 'unidade small'; tdUn.dataset.label = modoSorteio === 'CJ' ? 'Unidade Câmara de Julgamento' : 'Unidade Conselho Regulador'; tdUn.textContent = '';
-
   const tdDel = document.createElement('td');
   tdDel.className = 'acoes';
   tdDel.dataset.label = 'Ações';
@@ -230,7 +230,7 @@ function createRowElement(index) {
   });
   tdDel.appendChild(btnDel);
 
-  tr.append(tdOrdem, tdProc, tdAss, tdRec, tdUn, tdDel);
+  tr.append(tdOrdem, tdProc, tdAss, tdRec, tdDel);
   return tr;
 }
 
@@ -333,7 +333,7 @@ function sortearProcessos() {
     participantes.forEach(creg => {
       for (let i = 0; i < base; i++) {
         const row = linhas.pop();
-        row.querySelector('.unidade').textContent = creg;
+        row.dataset.unidade = creg;
         atribuicoesPorCreg[creg].total++;
         atribuicoesPorCreg[creg].assuntos[assunto] = (atribuicoesPorCreg[creg].assuntos[assunto] || 0) + 1;
       }
@@ -346,7 +346,7 @@ function sortearProcessos() {
       for (let i = 0; i < resto; i++) {
         const creg = candidatos[i];
         const row = linhas.pop();
-        row.querySelector('.unidade').textContent = creg;
+        row.dataset.unidade = creg;
         atribuicoesPorCreg[creg].total++;
         atribuicoesPorCreg[creg].assuntos[assunto] = (atribuicoesPorCreg[creg].assuntos[assunto] || 0) + 1;
       }
@@ -390,7 +390,7 @@ function sortearProcessos() {
     rows.forEach(r => {
       const numProc = r.querySelector('.col-processo input').value.trim();
       const assunto = r.querySelector('.col-assunto select').value;
-      const unidadeSorteada = r.querySelector('.unidade').textContent.trim();
+      const unidadeSorteada = r.dataset.unidade || '';
 
       const tr = document.createElement('tr');
       
@@ -401,8 +401,8 @@ function sortearProcessos() {
       tdAss.textContent = assunto;
 
       const tdUn = document.createElement('td');
-      tdUn.textContent = unidadeSorteada;
       tdUn.className = 'sorteado-unidade';
+      tdUn.textContent = unidadeSorteada;
 
       tr.append(tdProc, tdAss, tdUn);
       tbodyResult.appendChild(tr);
@@ -475,7 +475,7 @@ function coletarDados(rows, dataDistribuicao) {
       numProcesso: r.querySelector('.col-processo input').value.trim(),
       assunto: r.querySelector('.col-assunto select').value.trim(),
       dataDistribuicao,
-      unidade: r.querySelector('.unidade').textContent.trim()
+      unidade: r.dataset.unidade || ''
     };
 
     const escolha = r.querySelector('.col-decisao select').value.trim();

--- a/index.html
+++ b/index.html
@@ -106,7 +106,6 @@
               <th>Nº Processo</th>
               <th>Assunto</th>
               <th id="thRecurso">Recurso</th>
-              <th id="thUnidade">Unidade Conselho Regulador</th>
               <th><span class="sr-only">Ações</span></th>
             </tr>
           </thead>


### PR DESCRIPTION
## 📌 Descrição

Este PR remove a coluna redundante de *Unidade* na tabela de preenchimento dos processos, ajusta a largura das colunas para evitar cortes de texto e centraliza os dados na tabela de resultados pós-sorteio, além de aplicar melhorias de consistência visual nos selects.

---

## 🛠️ Alterações Realizadas

### 1. Remoção da coluna redundante de Unidade (`index.html` e `index.js`)
* **Tabela de Entrada (`#processTable`):** Removida a coluna `Unidade Conselho Regulador / Câmara de Julgamento` do cabeçalho e das linhas, mantendo apenas as 5 colunas ativas de preenchimento (*Ordem, Nº Processo, Assunto, Recurso/Defesa, Ações*).
* **Integridade do Sorteio:** O valor da unidade sorteada passou a ser armazenado internamente via `row.dataset.unidade`, garantindo funcionamento contínuo e transparente na montagem da tabela de resultado, na exportação para Word (`.doc`) e na gravação no Supabase.

### 2. Ajuste de Layout e Proporções (`index.css`)
* **Tabela de Entrada (`#processTable`):** Proporções redistribuídas para 5 colunas (`7%`, `26%`, `28%`, `26%`, `13%`), aproveitando o espaço liberado.
* **Selects:** Adicionado `min-width: 130px` para evitar que os textos *"Selecione o Assunto"* ou *"Houve defesa?"* sejam cortados.
* **Tabela de Resultados (`#resultTable`):** Todas as 3 colunas (*Nº Processo, Assunto, Sorteado Para*) e seus respectivos cabeçalhos foram centralizados com distribuição uniforme (`33%`, `34%`, `33%`).
* **Mobile / Responsividade:** Limpeza de seletores e regras obsoletas relacionadas a `td.unidade`.

### 3. Melhorias Visuais e de Usabilidade (`index.js`)
* **Placeholder cinza no Assunto (CREG):** O select de Assunto agora utiliza a classe `placeholder-select` para exibir o texto em cinza enquanto estiver em *"Selecione o Assunto"*, passando para a cor padrão após a escolha.
* **Padronização de textos:** Ajustado o placeholder de recurso para *"Selecione o Recurso"* e títulos com sigla (*"Conselho Regulador (CREG)"* / *"Câmara de Julgamento (CJ)"*).

---

## ✅ Testes e Validações

- [x] Testes unitários de aleatoriedade executados (`node tests/test_sorteio.mjs` - OK).
- [x] Validação visual em modo CREG e modo CJ.
- [x] Validação da tabela de resultados após execução do sorteio.
- [x] Validação da exportação do relatório Word (.doc) com as unidades atribuídas.