### PR TITLE
refactor: remove a tabela legada processos_sorteados

### DIFF
--- a/FLUXO-CJ.md
+++ b/FLUXO-CJ.md
@@ -4,9 +4,9 @@ Como um processo da Câmara de Julgamento (CJ) atravessa o sistema, do sorteio a
 julgamento registrado. Este documento é a referência de manutenção: o que cada
 peça faz, por que foi feita assim, e onde estão as regras.
 
-O Conselho Regulador (CREG) não está aqui — continua na tabela
-`processos_sorteados` até 27/08/2026, quando ganhou o mesmo par de tabelas —
-ver [FLUXO-CREG.md](FLUXO-CREG.md).
+O Conselho Regulador (CREG) não está aqui — usou uma tabela de sorteio à parte
+até 27/08/2026, quando ganhou o mesmo par de tabelas — ver
+[FLUXO-CREG.md](FLUXO-CREG.md).
 
 > **Reinício em 19/08/2026.** A série de julgados recomeçou nessa data: o
 > histórico importado da planilha saiu das tabelas de produção e ficou guardado
@@ -596,7 +596,6 @@ atual no Supabase e apaga os tokens locais; fechar a aba também descarta o
 
 | tabela | o navegador pode |
 |---|---|
-| `processos_sorteados` | INSERT (legado: nada escreve nela desde 27/08/2026) |
 | `acervo_creg` | INSERT |
 | `julgados_creg` | SELECT |
 | `acervo_cj` | INSERT |
@@ -678,7 +677,6 @@ Chaves e índices que sustentam as regras:
 | objeto | para quê |
 |---|---|
 | `acervo_creg_distribuicao_unica (num_processo, data_distribuicao, unidade)` | o mesmo sorteio CREG não é gravado duas vezes |
-| `ux_processos_sorteados_distribuicao` e `processos_sorteados_num_processo_15_digitos` | legado da tabela aposentada, mantidos com ela |
 | `acervo_cj_distribuicao_unica (num_processo, data_distribuicao, relator)` | sorteio/importação repetidos não duplicam; é o índice da busca do processo |
 | `julgados_cj_sessao_unica (num_processo, data_sessao)` | um processo não é julgado duas vezes na mesma sessão |
 | `pautas_cj.url` único | o mesmo PDF não é processado duas vezes |
@@ -770,9 +768,11 @@ Revisto depois da carga de recuperação, em 21/08/2026.
   anteriores sem cadeira conhecida — eles seguem pelo nome, porque inventar o
   número seria pior. Se alguém rodar o `restaurar_cj.sql`, o painel passa a
   misturar cadeiras e nomes até que essas composições sejam informadas.
-- ~~**CREG** continua em `processos_sorteados`.~~ Resolvido em 27/08/2026: o
-  Conselho ganhou `acervo_creg`, `julgados_creg` e `pautas_creg`, e o sorteio
-  passou a gravar no acervo. Ver [FLUXO-CREG.md](FLUXO-CREG.md).
+- ~~**CREG** continua numa tabela de sorteio à parte.~~ Resolvido em
+  27/08/2026: o Conselho ganhou `acervo_creg`, `julgados_creg` e `pautas_creg`,
+  e o sorteio passou a gravar no acervo. A tabela antiga foi removida do schema
+  em 02/09/2026, depois de o que ela guardava ser conferido em `acervo_creg`.
+  Ver [FLUXO-CREG.md](FLUXO-CREG.md).
 
 ### Decidido e encerrado
 
@@ -782,8 +782,8 @@ Revisto depois da carga de recuperação, em 21/08/2026.
   página de julgados e das atas em Word — o `schema.sql` derruba a coluna de
   quem já existia. **No Conselho Regulador ele voltou** em 27/08/2026, agora
   como campo livre digitado na tela do sorteio: fica em
-  `processos_sorteados.interessado` (anulável, porque os sorteios antigos não
-  têm o dado) e na ata do CREG.
+  `acervo_creg.interessado` (anulável, porque os sorteios antigos não têm o
+  dado) e na ata do CREG.
 - **Edição concorrente** não é preocupação: a secretaria é pequena e, se duas
   pessoas abrirem a mesma pauta, vale quem salvar por último.
 

--- a/FLUXO-CREG.md
+++ b/FLUXO-CREG.md
@@ -323,14 +323,15 @@ julgados novos têm unidade resolvida pelo gatilho.
 
 ### Os 81 sorteados em 27/08 vieram da tabela antiga
 
-No dia da virada, a tela em produção ainda era a que gravava em
-`processos_sorteados`, e o sorteio daquele dia — 81 processos, 27 para cada uma
-de CREG2, CREG3 e CREG4 — entrou lá. A migração `20260828…` copiou os 81 para
+No dia da virada, a tela em produção ainda era a que gravava na tabela antiga
+do sorteio, e o sorteio daquele dia — 81 processos, 27 para cada uma de CREG2,
+CREG3 e CREG4 — entrou lá. A migração `20260828…` copiou os 81 para
 `acervo_creg` com `origem = 'sorteio'`; sem ela ficariam distribuídos e
-invisíveis ao painel.
+invisíveis ao painel. Os pendentes passaram de 87 para 166.
 
-`processos_sorteados` **não foi esvaziada**: continua com as 81 linhas, como o
-registro do que a tela gravou na época. Os pendentes passaram de 87 para 166.
+A tabela antiga foi mantida por uns dias como o registro do que a tela gravou
+na época, e removida do schema em 02/09/2026 pela migração `20260902…` — depois
+de conferido, linha a linha, que as 81 estavam em `acervo_creg`.
 
 Dois desses 81 já constavam do acervo em outra unidade e outra data — são
 redistribuições legítimas, e o painel conta cada processo uma vez só, na
@@ -403,8 +404,8 @@ Todos os passos são idempotentes.
   `Com recurso`, `Sem recurso`, `Não se aplica` e `Pedido de revisão`; o acervo
   registrado traz `Ad Referendum` (38 linhas) e `Reexame Necessário` (15), e
   nenhum `Pedido de revisão`. Alinhar as duas listas é decisão do Conselho.
-- **`processos_sorteados` continua no schema**, sem ninguém escrevendo nela
-  desde 27/08/2026 — mas não vazia: guarda as 81 linhas daquele dia, como o
-  registro do que a tela gravou na época (a migração `20260828…` as copiou para
-  `acervo_creg`). Não foi derrubada porque é o objeto da migração
-  20260823165725 e porque apagar tabela é decisão de quem opera o banco.
+- ~~**A tabela antiga do sorteio continua no schema.**~~ Resolvido em
+  02/09/2026: a migração `20260902…` a removeu. O que ela guardava — as 81
+  linhas de 27/08 — já estava em `acervo_creg` desde a `20260828…`, e a
+  remoção só acontece depois de a migração conferir que nenhuma linha ficou
+  sem correspondente. `acervo_creg` é a única fonte do acervo do Conselho.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ A chave publicável é pública por natureza e pode ficar no código: ela identi
 
 > O passo a passo completo, com diagramas, está em **[FLUXO-CJ.md](FLUXO-CJ.md)**.
 
-A CJ deixou de compartilhar a tabela `processos_sorteados` com o Conselho Regulador e passou a ter as duas tabelas que a secretaria já usava na planilha:
+A CJ deixou de compartilhar uma tabela única de sorteio com o Conselho Regulador e passou a ter as duas tabelas que a secretaria já usava na planilha:
 
 - **`acervo_cj`** — uma linha por **distribuição** de um processo a um relator. Um processo redistribuído aparece mais de uma vez, com datas e relatores diferentes. É aqui que o sorteio da CJ grava: a cadeira sorteada (`CJ1`..`CJ5`) é o relator do processo, e quem ocupa cada cadeira sai da tabela `cadeiras_cj`.
 - **`julgados_cj`** — uma linha por processo levado a uma **sessão de julgamento**, ligada ao registro do acervo por `acervo_id`.
@@ -235,9 +235,9 @@ Rodar duas vezes não duplica nada: `pautas_cj.url` barra o documento repetido e
 > O que difere da Câmara, com as fórmulas traduzidas uma a uma, está em
 > **[FLUXO-CREG.md](FLUXO-CREG.md)**.
 
-Até 27/08/2026 o sorteio do CREG gravava em `processos_sorteados` — uma tabela
-sem acervo e sem julgados, medida provisória enquanto o Conselho não tinha o
-desenho da Câmara. Agora tem:
+Até 27/08/2026 o sorteio do CREG gravava numa tabela solta, sem acervo e sem
+julgados, medida provisória enquanto o Conselho não tinha o desenho da Câmara.
+Agora tem:
 
 - **`acervo_creg`** — uma linha por **distribuição** de um processo a uma unidade
   (`CREG1`..`CREG4`). É aqui que o sorteio do CREG grava. A unidade é o que se

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -17,63 +17,6 @@
 -- CREG a coluna é RECURSO e quem recebe é a UNIDADE (CREG1..CREG4). O CREG
 -- ainda calcula META 45 e a divergência em relação à CJ, que a Câmara não tem.
 
--- ── CREG: a tabela do sorteio antigo ────────────────────────────────────────
--- Até 27/08/2026 o sorteio do Conselho Regulador gravava aqui — uma tabela sem
--- acervo e sem julgados, medida provisória enquanto o CREG não tinha o desenho
--- da Câmara. Agora tem: index.js grava em acervo_creg.
---
--- Ela CONTINUA no schema, e não está vazia: guarda os 81 processos sorteados em
--- 27/08/2026, o último sorteio feito antes da virada. Esses registros foram
--- copiados para acervo_creg (migração 20260828…), e ficam aqui como o que a
--- tela gravou na época. Apagar tabela é decisão de quem opera o banco, não
--- efeito colateral de rodar um schema — e esta ainda é o objeto da migração
--- 20260823165725, que validou a restrição de 15 dígitos sobre o legado.
-create table if not exists public.processos_sorteados (
-  id                bigint generated always as identity primary key,
-  criado_em         timestamptz not null default now(),
-  modo              text        not null check (modo = 'CREG'),
-  data_hora         timestamptz not null,
-  ordem             int         not null,
-  num_processo      text        not null,
-  assunto           text        not null,
-  interessado       text,
-  data_distribuicao date        not null,
-  recurso           text        not null,
-  unidade           text        not null
-);
-
--- Campo livre digitado pela secretaria; sorteios anteriores não o têm, então a
--- coluna nasce anulável em vez de inventar valor para o histórico.
-alter table public.processos_sorteados
-  add column if not exists interessado text;
-
--- Criar em duas etapas mantinha a proteção para novas linhas enquanto uma base
--- antiga era conferida; a validação abaixo exige que nenhum legado inválido reste.
-do $$
-begin
-  if not exists (
-    select 1
-      from pg_constraint
-     where conrelid = 'public.processos_sorteados'::regclass
-       and conname = 'processos_sorteados_num_processo_15_digitos'
-  ) then
-    alter table public.processos_sorteados
-      add constraint processos_sorteados_num_processo_15_digitos
-      check (num_processo ~ '^[0-9]{15}$') not valid;
-  end if;
-end
-$$;
-
-alter table public.processos_sorteados
-  validate constraint processos_sorteados_num_processo_15_digitos;
-
-create index if not exists idx_processos_sorteados_modo_data
-  on public.processos_sorteados (modo, data_hora desc);
-
-create unique index if not exists ux_processos_sorteados_distribuicao
-  on public.processos_sorteados
-  (modo, num_processo, data_distribuicao, unidade);
-
 -- ── CJ · Acervo ──────────────────────────────────────────────────────────────
 -- Uma linha por DISTRIBUIÇÃO de um processo a um relator — não uma linha por
 -- processo. Um processo redistribuído aparece mais de uma vez, com datas e
@@ -318,8 +261,8 @@ alter table public.julgados_cj
 
 -- O interessado saiu da Câmara de Julgamento em 20/08/2026: lá ninguém o
 -- consultava e não valia a pena guardar nome de pessoa. No Conselho Regulador
--- ele voltou em 27/08/2026, digitado na tela do sorteio — por isso
--- processos_sorteados não entra nesta limpeza (a coluna é criada acima).
+-- ele voltou em 27/08/2026, digitado na tela do sorteio — por isso a limpeza é
+-- só das duas tabelas da Câmara, e acervo_creg mantém a coluna.
 alter table public.acervo_cj   drop column if exists interessado;
 alter table public.julgados_cj drop column if exists interessado;
 
@@ -629,7 +572,7 @@ revoke all on function public.processos_acervo_cj(int, text) from public, anon, 
 grant execute on function public.processos_acervo_cj(int, text) to authenticated;
 
 -- ── Segurança (RLS) ──────────────────────────────────────────────────────────
--- Duas camadas de proteção, iguais para as três tabelas:
+-- Duas camadas de proteção, iguais para as tabelas da Câmara:
 --
 -- 1. Somente INSERT. O site acrescenta registros, mas não pode ler, alterar nem
 --    apagar um sorteio já gravado. Consultas e relatórios são feitos pelo painel
@@ -645,14 +588,8 @@ grant execute on function public.processos_acervo_cj(int, text) to authenticated
 -- O gatilho acima é SECURITY DEFINER justamente por causa da regra 1: ele
 -- precisa LER o acervo para derivar os campos, e quem insere não tem esse
 -- direito.
-alter table public.processos_sorteados enable row level security;
-alter table public.acervo_cj           enable row level security;
-alter table public.julgados_cj         enable row level security;
-
-drop policy if exists "front pode inserir" on public.processos_sorteados;
-drop policy if exists "usuario autenticado pode inserir" on public.processos_sorteados;
-create policy "usuario autenticado pode inserir"
-  on public.processos_sorteados for insert to authenticated with check (true);
+alter table public.acervo_cj   enable row level security;
+alter table public.julgados_cj enable row level security;
 
 drop policy if exists "usuario autenticado pode inserir" on public.acervo_cj;
 create policy "usuario autenticado pode inserir"
@@ -670,22 +607,18 @@ create policy "usuario autenticado pode ler"
 -- O Supabase concede privilégios amplos aos papéis da API por padrão. RLS ainda
 -- bloquearia as linhas, mas os grants abaixo repetem o mesmo mínimo como segunda
 -- camada e deixam o schema idêntico num Postgres comum.
-revoke all privileges on table public.processos_sorteados, public.acervo_cj,
-                               public.julgados_cj, public.pautas_cj
+revoke all privileges on table public.acervo_cj, public.julgados_cj,
+                               public.pautas_cj
   from anon, authenticated;
-revoke all privileges on sequence public.processos_sorteados_id_seq,
-                                  public.acervo_cj_id_seq,
+revoke all privileges on sequence public.acervo_cj_id_seq,
                                   public.julgados_cj_id_seq,
                                   public.pautas_cj_id_seq
   from anon, authenticated;
 
 grant usage on schema public to anon, authenticated;
-grant insert on public.processos_sorteados to authenticated;
-grant insert on public.acervo_cj           to authenticated;
-grant select on public.julgados_cj         to authenticated;
-grant usage on sequence public.processos_sorteados_id_seq,
-                        public.acervo_cj_id_seq
-  to authenticated;
+grant insert on public.acervo_cj   to authenticated;
+grant select on public.julgados_cj to authenticated;
+grant usage on sequence public.acervo_cj_id_seq to authenticated;
 
 -- ── CREG · Acervo ────────────────────────────────────────────────────────────
 -- Uma linha por DISTRIBUIÇÃO de um processo a uma unidade (CREG1..CREG4) — não
@@ -1248,6 +1181,200 @@ revoke all privileges on sequence public.acervo_creg_id_seq,
 grant insert on public.acervo_creg   to authenticated;
 grant select on public.julgados_creg to authenticated;
 grant usage  on sequence public.acervo_creg_id_seq to authenticated;
+
+-- ── Histórico de sorteios ────────────────────────────────────────────────────
+-- O que alimenta historico-cj.html e historico-creg.html: as rodadas de sorteio
+-- já realizadas, uma tela por colegiado, como o painel do acervo.
+--
+-- Um SORTEIO é o lote que a tela gravou de uma vez: as linhas do acervo que
+-- compartilham (data_distribuicao, sorteado_em). index.js usa um só instante
+-- para o lote inteiro — ver "Um só instante para o sorteio inteiro" lá —, então
+-- o carimbo já identifica a rodada e o histórico não precisa de tabela nova nem
+-- de escrever coisa alguma: consultar não pode mexer no que está gravado.
+--
+-- O carimbo pode faltar, e por isso a chave é o PAR (data, carimbo) e não o
+-- carimbo sozinho: as quatro rodadas da Câmara de 2026 entraram num lote só, em
+-- 21/08/2026, sem `sorteado_em`. Nelas quem data o sorteio é a distribuição, e
+-- a tela mostra a rodada sem horário em vez de inventar um.
+--
+-- ONDE O HISTÓRICO COMEÇA: em `origem = 'sorteio'`, e a partir do marco abaixo.
+-- É o recorte do que o SISTEMA distribuiu, que é o que esta tela promete.
+--
+--   • 'planilha' fica de fora — acervo herdado das planilhas de gabinete, que
+--     nunca foi um evento de sorteio; listá-lo inventaria rodadas que não houve
+--     (são 3.064 linhas no CREG, contra 81 de sorteio).
+--   • 'ata' também fica de fora — sorteio de verdade, mas anterior ao sistema e
+--     conhecido só pelo PDF publicado no SEI.
+--
+-- A primeira versão de historico_sorteios não tinha parâmetro: servia os dois
+-- colegiados na mesma lista. `create or replace` não muda a assinatura de uma
+-- função, então a antiga precisa sair antes da nova entrar.
+drop function if exists public.historico_sorteios();
+
+create or replace function public.historico_marco()
+returns date
+language sql
+immutable
+set search_path = ''
+as $$
+  -- 27/08/2026: o dia do primeiro sorteio feito na tela — os 81 processos do
+  -- Conselho Regulador que processos_sorteados gravou e que hoje vivem em
+  -- acervo_creg (migração 20260828…). Aquela tabela provisória vai ser
+  -- removida, e por isso o histórico lê o acervo, nunca ela.
+  --
+  -- O MESMO corte vale para os dois colegiados, de propósito: a série começa no
+  -- mesmo dia para a Câmara e para o Conselho. As quatro rodadas da Câmara de
+  -- 2026 (29/06 a 14/08) ficam de fora — entraram no acervo num lote só, em
+  -- 21/08, sem carimbo de hora, e são anteriores ao marco. A Câmara começa com
+  -- o histórico vazio e o preenche no próximo sorteio.
+  --
+  -- Mora numa função, e não repetido nas duas consultas, porque corte escrito
+  -- em dois lugares é corte que vai divergir. Ninguém a executa pela API: as
+  -- duas funções do histórico são SECURITY DEFINER e a chamam como dono.
+  select date '2026-08-27'
+$$;
+
+revoke all on function public.historico_marco() from public, anon, authenticated, service_role;
+
+create or replace function public.historico_sorteios(p_colegiado text)
+returns table (
+  data_sorteio date,
+  sorteado_em  timestamptz,
+  processos    int,
+  destinos     text[]
+)
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  marco constant date := public.historico_marco();
+begin
+  if (select auth.uid()) is null then
+    raise exception 'autenticação exigida' using errcode = '28000';
+  end if;
+
+  if coalesce(p_colegiado, '') not in ('CJ', 'CREG') then
+    raise exception 'colegiado desconhecido: %', p_colegiado using errcode = '22023';
+  end if;
+
+  return query
+  -- Os destinos saem por extenso, não como contagem: "CREG1, CREG2, CREG4" diz
+  -- quem participou da rodada, e "3" só diz quantos foram.
+  select a.data_distribuicao, a.sorteado_em, count(*)::int,
+         array_agg(distinct a.relator order by a.relator)
+    from public.acervo_cj a
+   where p_colegiado = 'CJ'
+     and a.origem = 'sorteio'
+     and a.data_distribuicao >= marco
+   group by a.data_distribuicao, a.sorteado_em
+   union all
+  select b.data_distribuicao, b.sorteado_em, count(*)::int,
+         array_agg(distinct b.unidade order by b.unidade)
+    from public.acervo_creg b
+   where p_colegiado = 'CREG'
+     and b.origem = 'sorteio'
+     and b.data_distribuicao >= marco
+   group by b.data_distribuicao, b.sorteado_em
+   -- Mais recente primeiro, que é como um histórico é lido. `nulls last` deixa
+   -- a rodada sem carimbo depois da carimbada do mesmo dia, e não antes dela.
+   order by 1 desc, 2 desc nulls last;
+end;
+$$;
+
+revoke all on function public.historico_sorteios(text) from public, anon, service_role;
+grant execute on function public.historico_sorteios(text) to authenticated;
+
+-- ── Os processos de um sorteio ───────────────────────────────────────────────
+-- A lista que o histórico abre ao clicar numa rodada. Mesma razão de
+-- processos_acervo_cj existir: os dois acervos são fechados ao navegador, e
+-- abrir SELECT neles só para montar esta tela entregaria o acervo inteiro ao
+-- cliente.
+--
+-- Uma função para os dois colegiados, com o vocabulário traduzido aqui: o que
+-- na Câmara é relator/defesa e no Conselho é unidade/recurso sai como
+-- destino/decisao. Sem essa tradução, a tela precisaria de dois caminhos para
+-- desenhar a mesma tabela.
+--
+-- `is not distinct from` e não `=`: o carimbo das rodadas antigas é nulo, e um
+-- `=` com nulo devolveria lista vazia justamente para elas.
+create or replace function public.processos_sorteio(
+  p_colegiado   text,
+  p_data        date,
+  p_sorteado_em timestamptz default null
+)
+returns table (
+  ordem        int,
+  num_processo text,
+  destino      text,
+  responsavel  text,
+  assunto      text,
+  decisao      text,
+  interessado  text
+)
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  marco constant date := public.historico_marco();
+begin
+  if (select auth.uid()) is null then
+    raise exception 'autenticação exigida' using errcode = '28000';
+  end if;
+
+  if coalesce(p_colegiado, '') not in ('CJ', 'CREG') then
+    raise exception 'colegiado desconhecido: %', p_colegiado using errcode = '22023';
+  end if;
+
+  return query
+  select a.ordem,
+         a.num_processo,
+         a.relator,
+         -- O ocupante da cadeira NA DATA do sorteio, não o de hoje: histórico
+         -- que reescreve o relator a cada mudança de composição deixa de ser
+         -- histórico. Cadeira sem de-para no período sai pelo próprio rótulo.
+         coalesce(c.conselheiro, a.relator),
+         a.assunto,
+         -- Na Câmara a coluna é a DEFESA, booleana. O texto em `recurso` é o
+         -- legado da época em que a CJ dividia a tabela com o Conselho: sai
+         -- como está, porque relê-lo como defesa inventaria a decisão. E
+         -- defesa nula tem de cair nesse legado, não virar 'Não'.
+         case when a.defesa is null then a.recurso
+              when a.defesa        then 'Sim'
+              else 'Não' end,
+         null::text
+    from public.acervo_cj a
+    left join public.cadeiras_cj c
+           on c.cadeira = a.relator
+          and a.data_distribuicao >= c.desde
+          and (c.ate is null or a.data_distribuicao <= c.ate)
+   where p_colegiado = 'CJ'
+     and a.data_distribuicao = p_data
+     and a.sorteado_em is not distinct from p_sorteado_em
+     and a.origem = 'sorteio'
+     and a.data_distribuicao >= marco
+   union all
+  select b.ordem, b.num_processo, b.unidade, null::text,
+         b.assunto, b.recurso, b.interessado
+    from public.acervo_creg b
+   where p_colegiado = 'CREG'
+     and b.data_distribuicao = p_data
+     and b.sorteado_em is not distinct from p_sorteado_em
+     and b.origem = 'sorteio'
+     and b.data_distribuicao >= marco
+   -- A ordem do sorteio é a da ata. Linha sem ordem — gravação que não a
+   -- registrou — vai para o fim, com o número do processo como desempate
+   -- estável.
+   order by 1 nulls last, 2;
+end;
+$$;
+
+revoke all on function public.processos_sorteio(text, date, timestamptz)
+  from public, anon, service_role;
+grant execute on function public.processos_sorteio(text, date, timestamptz) to authenticated;
 
 -- ── Monitoramento / Keep-Alive (UptimeRobot / Health Check) ──────────────────
 -- Função leve sem efeitos colaterais (STABLE) que permite requisições HEAD/GET

--- a/sql/verificacao_cj.sql
+++ b/sql/verificacao_cj.sql
@@ -33,16 +33,6 @@ select 2, 'ERRO',
           having count(*) > 1) x)
 
 union all
-select 2.5, 'ERRO',
-       'Distribuição CREG repetida',
-       'mesmo processo, data e unidade mais de uma vez',
-       (select count(*) from (
-          select 1 from public.processos_sorteados
-           where modo = 'CREG'
-           group by modo, num_processo, data_distribuicao, unidade
-          having count(*) > 1) x)
-
-union all
 select 3, 'ERRO',
        'Julgado apontando para processo diferente no acervo',
        'acervo_id existe mas o num_processo dos dois não bate',
@@ -72,12 +62,6 @@ select 6, 'ERRO',
        'processo SEI da AGR tem 15 dígitos, só dígitos',
        (select count(*) from public.julgados_cj where num_processo !~ '^[0-9]{15}$')
 
-union all
-select 6.5, 'AVISO',
-       'Número de processo fora do padrão no CREG',
-       'legado preservado; novos registros já exigem 15 dígitos, só dígitos',
-       (select count(*) from public.processos_sorteados
-         where modo = 'CREG' and num_processo !~ '^[0-9]{15}$')
 
 -- ── Rótulos ──────────────────────────────────────────────────────────────────
 
@@ -215,12 +199,6 @@ select 23, 'INFO',
        'Pautas já sincronizadas da AGR',
        'documentos processados por sincronizacao/sincronizar.py',
        (select count(*) from public.pautas_cj where url like 'https://%')
-
-union all
-select 24, 'ERRO',
-       'Processo CJ ainda na tabela antiga',
-       'processos_sorteados deixou de ser fonte de dados da Câmara',
-       (select count(*) from public.processos_sorteados where modo <> 'CREG')
 
 )
 select gravidade, conferencia, quantidade, explicacao

--- a/supabase/migrations/20260901134138_historico_sorteios.sql
+++ b/supabase/migrations/20260901134138_historico_sorteios.sql
@@ -1,0 +1,176 @@
+-- Histórico de sorteios: a consulta das rodadas já realizadas
+-- (historico-cj.html e historico-creg.html).
+--
+-- Só acrescenta duas funções de LEITURA. Nenhuma tabela, coluna, política ou
+-- privilégio de escrita muda — o histórico é uma consulta, e o que já está
+-- gravado continua exatamente como está. Por isso a migração é repetível.
+--
+-- O conteúdo abaixo é idêntico ao bloco "Histórico de sorteios" do
+-- sql/schema.sql; um teste compara as definições que as migrações entregam com
+-- as do schema, e uma cópia que divergir aparece como falha.
+
+-- A primeira versão desta função não tinha parâmetro: servia os dois colegiados
+-- na mesma lista. `create or replace` não muda a assinatura de uma função, então
+-- a antiga precisa sair antes da nova entrar.
+drop function if exists public.historico_sorteios();
+
+-- ── Histórico de sorteios ────────────────────────────────────────────────────
+-- O que alimenta historico-cj.html e historico-creg.html: as rodadas de sorteio
+-- já realizadas, uma tela por colegiado, como o painel do acervo.
+--
+-- Um SORTEIO é o lote que a tela gravou de uma vez: as linhas do acervo que
+-- compartilham (data_distribuicao, sorteado_em). index.js usa um só instante
+-- para o lote inteiro — ver "Um só instante para o sorteio inteiro" lá —, então
+-- o carimbo já identifica a rodada e o histórico não precisa de tabela nova nem
+-- de escrever coisa alguma: consultar não pode mexer no que está gravado.
+--
+-- O carimbo pode faltar, e por isso a chave é o PAR (data, carimbo) e não o
+-- carimbo sozinho: as quatro rodadas da Câmara de 2026 entraram num lote só, em
+-- 21/08/2026, sem `sorteado_em`. Nelas quem data o sorteio é a distribuição, e
+-- a tela mostra a rodada sem horário em vez de inventar um.
+--
+-- ONDE O HISTÓRICO COMEÇA: em `origem = 'sorteio'`, e só. É o recorte do que o
+-- SISTEMA distribuiu, que é o que esta tela promete.
+--
+--   • 'planilha' fica de fora — acervo herdado das planilhas de gabinete, que
+--     nunca foi um evento de sorteio; listá-lo inventaria rodadas que não houve
+--     (são 3.064 linhas no CREG, contra 81 de sorteio).
+--   • 'ata' também fica de fora — sorteio de verdade, mas anterior ao sistema e
+--     conhecido só pelo PDF publicado no SEI. O histórico do Conselho começa no
+--     primeiro sorteio feito NESTA tela: o de 27/08/2026, com 81 processos.
+--
+-- Esse sorteio de 27/08 foi gravado por processos_sorteados, a tabela provisória
+-- de antes de o CREG ter o desenho da Câmara. As 81 linhas já estão em
+-- acervo_creg (migração 20260828…), e é de lá que este histórico as lê —
+-- processos_sorteados vai ser removida e nenhuma consulta pode depender dela.
+create or replace function public.historico_sorteios(p_colegiado text)
+returns table (
+  data_sorteio date,
+  sorteado_em  timestamptz,
+  processos    int,
+  destinos     text[]
+)
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+begin
+  if (select auth.uid()) is null then
+    raise exception 'autenticação exigida' using errcode = '28000';
+  end if;
+
+  if coalesce(p_colegiado, '') not in ('CJ', 'CREG') then
+    raise exception 'colegiado desconhecido: %', p_colegiado using errcode = '22023';
+  end if;
+
+  return query
+  -- Os destinos saem por extenso, não como contagem: "CREG1, CREG2, CREG4" diz
+  -- quem participou da rodada, e "3" só diz quantos foram.
+  select a.data_distribuicao, a.sorteado_em, count(*)::int,
+         array_agg(distinct a.relator order by a.relator)
+    from public.acervo_cj a
+   where p_colegiado = 'CJ'
+     and a.origem = 'sorteio'
+   group by a.data_distribuicao, a.sorteado_em
+   union all
+  select b.data_distribuicao, b.sorteado_em, count(*)::int,
+         array_agg(distinct b.unidade order by b.unidade)
+    from public.acervo_creg b
+   where p_colegiado = 'CREG'
+     and b.origem = 'sorteio'
+   group by b.data_distribuicao, b.sorteado_em
+   -- Mais recente primeiro, que é como um histórico é lido. `nulls last` deixa
+   -- a rodada sem carimbo depois da carimbada do mesmo dia, e não antes dela.
+   order by 1 desc, 2 desc nulls last;
+end;
+$$;
+
+revoke all on function public.historico_sorteios(text) from public, anon, service_role;
+grant execute on function public.historico_sorteios(text) to authenticated;
+
+-- ── Os processos de um sorteio ───────────────────────────────────────────────
+-- A lista que o histórico abre ao clicar numa rodada. Mesma razão de
+-- processos_acervo_cj existir: os dois acervos são fechados ao navegador, e
+-- abrir SELECT neles só para montar esta tela entregaria o acervo inteiro ao
+-- cliente.
+--
+-- Uma função para os dois colegiados, com o vocabulário traduzido aqui: o que
+-- na Câmara é relator/defesa e no Conselho é unidade/recurso sai como
+-- destino/decisao. Sem essa tradução, a tela precisaria de dois caminhos para
+-- desenhar a mesma tabela.
+--
+-- `is not distinct from` e não `=`: o carimbo das rodadas antigas é nulo, e um
+-- `=` com nulo devolveria lista vazia justamente para elas.
+create or replace function public.processos_sorteio(
+  p_colegiado   text,
+  p_data        date,
+  p_sorteado_em timestamptz default null
+)
+returns table (
+  ordem        int,
+  num_processo text,
+  destino      text,
+  responsavel  text,
+  assunto      text,
+  decisao      text,
+  interessado  text
+)
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+begin
+  if (select auth.uid()) is null then
+    raise exception 'autenticação exigida' using errcode = '28000';
+  end if;
+
+  if coalesce(p_colegiado, '') not in ('CJ', 'CREG') then
+    raise exception 'colegiado desconhecido: %', p_colegiado using errcode = '22023';
+  end if;
+
+  return query
+  select a.ordem,
+         a.num_processo,
+         a.relator,
+         -- O ocupante da cadeira NA DATA do sorteio, não o de hoje: histórico
+         -- que reescreve o relator a cada mudança de composição deixa de ser
+         -- histórico. Cadeira sem de-para no período sai pelo próprio rótulo.
+         coalesce(c.conselheiro, a.relator),
+         a.assunto,
+         -- Na Câmara a coluna é a DEFESA, booleana. O texto em `recurso` é o
+         -- legado da época em que a CJ dividia a tabela com o Conselho: sai
+         -- como está, porque relê-lo como defesa inventaria a decisão. E
+         -- defesa nula tem de cair nesse legado, não virar 'Não'.
+         case when a.defesa is null then a.recurso
+              when a.defesa        then 'Sim'
+              else 'Não' end,
+         null::text
+    from public.acervo_cj a
+    left join public.cadeiras_cj c
+           on c.cadeira = a.relator
+          and a.data_distribuicao >= c.desde
+          and (c.ate is null or a.data_distribuicao <= c.ate)
+   where p_colegiado = 'CJ'
+     and a.data_distribuicao = p_data
+     and a.sorteado_em is not distinct from p_sorteado_em
+     and a.origem = 'sorteio'
+   union all
+  select b.ordem, b.num_processo, b.unidade, null::text,
+         b.assunto, b.recurso, b.interessado
+    from public.acervo_creg b
+   where p_colegiado = 'CREG'
+     and b.data_distribuicao = p_data
+     and b.sorteado_em is not distinct from p_sorteado_em
+     and b.origem = 'sorteio'
+   -- A ordem do sorteio é a da ata. Linha sem ordem — gravação que não a
+   -- registrou — vai para o fim, com o número do processo como desempate
+   -- estável.
+   order by 1 nulls last, 2;
+end;
+$$;
+
+revoke all on function public.processos_sorteio(text, date, timestamptz)
+  from public, anon, service_role;
+grant execute on function public.processos_sorteio(text, date, timestamptz) to authenticated;

--- a/supabase/migrations/20260901135740_historico_sorteios_marco_unico.sql
+++ b/supabase/migrations/20260901135740_historico_sorteios_marco_unico.sql
@@ -1,0 +1,161 @@
+-- Histórico de sorteios: marco único para os dois colegiados.
+--
+-- A série passa a começar em 27/08/2026 — o dia do primeiro sorteio feito na
+-- tela, os 81 processos do Conselho — tanto na Câmara quanto no Conselho. As
+-- quatro rodadas antigas da Câmara (29/06 a 14/08) saem do histórico: são
+-- anteriores ao marco.
+--
+-- Só funções de LEITURA. Nenhuma tabela, coluna, política ou privilégio de
+-- escrita muda, e a migração é repetível.
+
+create or replace function public.historico_marco()
+returns date
+language sql
+immutable
+set search_path = ''
+as $$
+  -- 27/08/2026: o dia do primeiro sorteio feito na tela — os 81 processos do
+  -- Conselho Regulador que processos_sorteados gravou e que hoje vivem em
+  -- acervo_creg (migração 20260828…). Aquela tabela provisória vai ser
+  -- removida, e por isso o histórico lê o acervo, nunca ela.
+  --
+  -- O MESMO corte vale para os dois colegiados, de propósito: a série começa no
+  -- mesmo dia para a Câmara e para o Conselho. As quatro rodadas da Câmara de
+  -- 2026 (29/06 a 14/08) ficam de fora — entraram no acervo num lote só, em
+  -- 21/08, sem carimbo de hora, e são anteriores ao marco. A Câmara começa com
+  -- o histórico vazio e o preenche no próximo sorteio.
+  --
+  -- Mora numa função, e não repetido nas duas consultas, porque corte escrito
+  -- em dois lugares é corte que vai divergir. Ninguém a executa pela API: as
+  -- duas funções do histórico são SECURITY DEFINER e a chamam como dono.
+  select date '2026-08-27'
+$$;
+
+revoke all on function public.historico_marco() from public, anon, authenticated, service_role;
+
+create or replace function public.historico_sorteios(p_colegiado text)
+returns table (
+  data_sorteio date,
+  sorteado_em  timestamptz,
+  processos    int,
+  destinos     text[]
+)
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  marco constant date := public.historico_marco();
+begin
+  if (select auth.uid()) is null then
+    raise exception 'autenticação exigida' using errcode = '28000';
+  end if;
+
+  if coalesce(p_colegiado, '') not in ('CJ', 'CREG') then
+    raise exception 'colegiado desconhecido: %', p_colegiado using errcode = '22023';
+  end if;
+
+  return query
+  -- Os destinos saem por extenso, não como contagem: "CREG1, CREG2, CREG4" diz
+  -- quem participou da rodada, e "3" só diz quantos foram.
+  select a.data_distribuicao, a.sorteado_em, count(*)::int,
+         array_agg(distinct a.relator order by a.relator)
+    from public.acervo_cj a
+   where p_colegiado = 'CJ'
+     and a.origem = 'sorteio'
+     and a.data_distribuicao >= marco
+   group by a.data_distribuicao, a.sorteado_em
+   union all
+  select b.data_distribuicao, b.sorteado_em, count(*)::int,
+         array_agg(distinct b.unidade order by b.unidade)
+    from public.acervo_creg b
+   where p_colegiado = 'CREG'
+     and b.origem = 'sorteio'
+     and b.data_distribuicao >= marco
+   group by b.data_distribuicao, b.sorteado_em
+   -- Mais recente primeiro, que é como um histórico é lido. `nulls last` deixa
+   -- a rodada sem carimbo depois da carimbada do mesmo dia, e não antes dela.
+   order by 1 desc, 2 desc nulls last;
+end;
+$$;
+
+revoke all on function public.historico_sorteios(text) from public, anon, service_role;
+grant execute on function public.historico_sorteios(text) to authenticated;
+
+create or replace function public.processos_sorteio(
+  p_colegiado   text,
+  p_data        date,
+  p_sorteado_em timestamptz default null
+)
+returns table (
+  ordem        int,
+  num_processo text,
+  destino      text,
+  responsavel  text,
+  assunto      text,
+  decisao      text,
+  interessado  text
+)
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  marco constant date := public.historico_marco();
+begin
+  if (select auth.uid()) is null then
+    raise exception 'autenticação exigida' using errcode = '28000';
+  end if;
+
+  if coalesce(p_colegiado, '') not in ('CJ', 'CREG') then
+    raise exception 'colegiado desconhecido: %', p_colegiado using errcode = '22023';
+  end if;
+
+  return query
+  select a.ordem,
+         a.num_processo,
+         a.relator,
+         -- O ocupante da cadeira NA DATA do sorteio, não o de hoje: histórico
+         -- que reescreve o relator a cada mudança de composição deixa de ser
+         -- histórico. Cadeira sem de-para no período sai pelo próprio rótulo.
+         coalesce(c.conselheiro, a.relator),
+         a.assunto,
+         -- Na Câmara a coluna é a DEFESA, booleana. O texto em `recurso` é o
+         -- legado da época em que a CJ dividia a tabela com o Conselho: sai
+         -- como está, porque relê-lo como defesa inventaria a decisão. E
+         -- defesa nula tem de cair nesse legado, não virar 'Não'.
+         case when a.defesa is null then a.recurso
+              when a.defesa        then 'Sim'
+              else 'Não' end,
+         null::text
+    from public.acervo_cj a
+    left join public.cadeiras_cj c
+           on c.cadeira = a.relator
+          and a.data_distribuicao >= c.desde
+          and (c.ate is null or a.data_distribuicao <= c.ate)
+   where p_colegiado = 'CJ'
+     and a.data_distribuicao = p_data
+     and a.sorteado_em is not distinct from p_sorteado_em
+     and a.origem = 'sorteio'
+     and a.data_distribuicao >= marco
+   union all
+  select b.ordem, b.num_processo, b.unidade, null::text,
+         b.assunto, b.recurso, b.interessado
+    from public.acervo_creg b
+   where p_colegiado = 'CREG'
+     and b.data_distribuicao = p_data
+     and b.sorteado_em is not distinct from p_sorteado_em
+     and b.origem = 'sorteio'
+     and b.data_distribuicao >= marco
+   -- A ordem do sorteio é a da ata. Linha sem ordem — gravação que não a
+   -- registrou — vai para o fim, com o número do processo como desempate
+   -- estável.
+   order by 1 nulls last, 2;
+end;
+$$;
+
+revoke all on function public.processos_sorteio(text, date, timestamptz)
+  from public, anon, service_role;
+grant execute on function public.processos_sorteio(text, date, timestamptz) to authenticated;

--- a/supabase/migrations/20260902120000_remover_processos_sorteados.sql
+++ b/supabase/migrations/20260902120000_remover_processos_sorteados.sql
@@ -1,0 +1,50 @@
+-- Remove processos_sorteados, a tabela do sorteio antigo do Conselho Regulador.
+--
+-- Ela foi medida provisória: até 27/08/2026 o CREG não tinha o desenho da
+-- Câmara (acervo + julgados + pautas) e o sorteador gravava numa tabela solta,
+-- sem acervo, sem julgados e sem vínculo com nada. Desde a migração
+-- 20260827150000 o Conselho tem o par completo, e index.js grava em
+-- acervo_creg.
+--
+-- O que ela guardava — os 81 processos do sorteio de 27/08/2026, o último
+-- feito antes da virada — foi copiado para acervo_creg pela migração
+-- 20260828090000, com origem = 'sorteio'. Aquela migração deixou a tabela de
+-- pé de propósito: apagar tabela com dado dentro não é efeito colateral de
+-- rodar um schema, é decisão de quem opera o banco. Esta migração é essa
+-- decisão, tomada depois de a cópia ter sido conferida linha a linha.
+--
+-- Nada mais depende dela: nenhuma FK aponta para cá, nenhuma view a lê,
+-- nenhuma função a consulta e o front não a conhece. O índice, a restrição de
+-- 15 dígitos, a política de RLS e a sequência caem junto com a tabela.
+
+-- A cópia é conferida agora, e não presumida: se sobrar uma linha sem
+-- correspondente em acervo_creg, a migração para em vez de apagar dado que
+-- ninguém mais teria como recuperar. Repetível — quando a tabela já não existe
+-- não há o que conferir nem o que derrubar.
+do $$
+declare
+  sem_copia bigint;
+begin
+  if to_regclass('public.processos_sorteados') is null then
+    return;
+  end if;
+
+  select count(*) into sem_copia
+    from public.processos_sorteados p
+   where not exists (
+     select 1
+       from public.acervo_creg a
+      where a.num_processo      = p.num_processo
+        and a.unidade           = p.unidade
+        and a.data_distribuicao = p.data_distribuicao
+   );
+
+  if sem_copia > 0 then
+    raise exception
+      'processos_sorteados tem % linha(s) fora de acervo_creg; a cópia '
+      '(migração 20260828090000) precisa rodar antes da remoção', sem_copia;
+  end if;
+end
+$$;
+
+drop table if exists public.processos_sorteados;

--- a/tests/test_cj.py
+++ b/tests/test_cj.py
@@ -38,6 +38,11 @@ MIGRACAO_HARDENING = RAIZ / 'supabase' / 'migrations' / \
     '20260827104200_restringir_cadeiras_e_ping.sql'
 MIGRACAO_INTERESSADO = RAIZ / 'supabase' / 'migrations' / \
     '20260827160000_interessado_creg.sql'
+# Derruba a tabela do sorteio antigo do Conselho, mas só depois de conferir que
+# o que ela guardava está em acervo_creg. Rodada à parte num teste, para provar
+# que a conferência é de verdade e não decoração.
+MIGRACAO_REMOCAO = RAIZ / 'supabase' / 'migrations' / \
+    '20260902120000_remover_processos_sorteados.sql'
 
 testes = []
 
@@ -176,7 +181,6 @@ def rls_da_cada_tabela_o_minimo(cur):
     existir política de UPDATE nem de DELETE em lugar nenhum.
     """
     esperado = {
-        'processos_sorteados': {'INSERT'},
         'acervo_cj': {'INSERT'},
         'julgados_cj': {'SELECT'},
         'pautas_cj': set(),
@@ -207,7 +211,6 @@ def navegador_nao_atualiza_nem_apaga_julgados(cur):
 def privilegios_sql_repetem_o_minimo_da_rls(cur):
     """Grants padrão do Supabase não podem ampliar o que cada política permite."""
     esperado = {
-        ('authenticated', 'processos_sorteados'): {'INSERT'},
         ('authenticated', 'acervo_cj'): {'INSERT'},
         ('authenticated', 'julgados_cj'): {'SELECT'},
         ('authenticated', 'acervo_creg'): {'INSERT'},
@@ -216,10 +219,9 @@ def privilegios_sql_repetem_o_minimo_da_rls(cur):
     cur.execute("""select grantee, table_name, privilege_type
                      from information_schema.role_table_grants
                     where table_schema = 'public'
-                      and table_name in ('processos_sorteados', 'acervo_cj',
-                                         'julgados_cj', 'pautas_cj', 'cadeiras_cj',
-                                         'acervo_creg', 'julgados_creg',
-                                         'pautas_creg')
+                      and table_name in ('acervo_cj', 'julgados_cj', 'pautas_cj',
+                                         'cadeiras_cj', 'acervo_creg',
+                                         'julgados_creg', 'pautas_creg')
                       and grantee in ('anon', 'authenticated')""")
     obtido = {}
     for papel, tabela, privilegio in cur.fetchall():
@@ -231,7 +233,6 @@ def privilegios_sql_repetem_o_minimo_da_rls(cur):
                     where object_schema = 'public' and object_type = 'SEQUENCE'
                       and grantee in ('anon', 'authenticated')""")
     assert set(cur.fetchall()) == {
-        ('authenticated', 'processos_sorteados_id_seq', 'USAGE'),
         ('authenticated', 'acervo_cj_id_seq', 'USAGE'),
         ('authenticated', 'acervo_creg_id_seq', 'USAGE'),
     }
@@ -271,19 +272,33 @@ def ping_tem_search_path_fixo_e_privilegio_minimo(cur):
 
 
 @teste
-def tabela_antiga_recusa_cj(cur):
-    """processos_sorteados é só do CREG: processo da Câmara não entra ali."""
-    try:
-        cur.execute("""insert into processos_sorteados
-                       (modo, data_hora, ordem, num_processo, assunto,
-                        data_distribuicao, recurso, unidade)
-                       values ('CJ', now(), 1, '202600029000001', 'Auto de Infração',
-                               current_date, 'Com recurso', 'CJ1')""")
-    except psycopg2.errors.CheckViolation:
-        return
-    finally:
-        cur.connection.rollback()
-    raise AssertionError('processos_sorteados ainda aceita CJ')
+def tabela_antiga_foi_removida(cur):
+    """processos_sorteados saiu do schema, e com ela tudo que pendurava nela.
+
+    Era a tabela do sorteio antigo do Conselho: sem acervo, sem julgados e sem
+    vínculo com nada, provisória até o CREG ganhar o desenho da Câmara. O que
+    ela guardava vive em acervo_creg desde a migração 20260828090000, e a
+    20260902120000 a derrubou.
+
+    Não basta a tabela ter sumido: sequência, política de RLS e privilégio
+    sobrevivem a um drop malfeito e continuariam aparecendo em auditoria.
+    """
+    assert uma(cur, "select to_regclass('public.processos_sorteados')") is None
+    assert uma(cur, "select to_regclass('public.processos_sorteados_id_seq')") is None
+
+    assert uma(cur, """select count(*) from pg_policies
+                        where schemaname = 'public'
+                          and tablename = 'processos_sorteados'""") == 0
+    assert uma(cur, """select count(*) from information_schema.role_table_grants
+                        where table_schema = 'public'
+                          and table_name = 'processos_sorteados'""") == 0
+
+    # O índice e a restrição de 15 dígitos caíram junto com a tabela.
+    assert uma(cur, """select count(*) from pg_indexes
+                        where schemaname = 'public'
+                          and indexname like '%processos_sorteados%'""") == 0
+    assert uma(cur, """select count(*) from pg_constraint
+                        where conname like '%processos_sorteados%'""") == 0
 
 
 # ── Testes: importação da planilha ───────────────────────────────────────────
@@ -605,39 +620,41 @@ def sorteio_repetido_e_barrado(cur):
 
 @teste
 def creg_recusa_a_mesma_distribuicao_duas_vezes(cur):
-    """Mesmo processo, dia e unidade do CREG não podem virar duas linhas."""
-    valores = ("CREG", "2026-08-22 09:00:00+00", "202600029000020",
-               "2026-08-22", "CREG1")
-    cur.execute("""insert into processos_sorteados
-                   (modo, data_hora, ordem, num_processo, assunto,
-                    data_distribuicao, recurso, unidade)
-                   values (%s, %s, 1, %s, 'Requerimento', %s, 'Não se aplica', %s)""",
+    """Mesmo processo, dia e unidade do CREG não podem virar duas linhas.
+
+    A regra saiu da tabela antiga junto com ela: quem a carrega hoje é a
+    restrição acervo_creg_distribuicao_unica.
+    """
+    valores = ("202600029000020", "CREG1", "2026-08-22")
+    cur.execute("""insert into acervo_creg
+                   (num_processo, unidade, data_distribuicao, assunto, recurso, ordem)
+                   values (%s, %s, %s, 'Requerimento', 'Não se aplica', 1)""",
                 valores)
     try:
-        cur.execute("""insert into processos_sorteados
-                       (modo, data_hora, ordem, num_processo, assunto,
-                        data_distribuicao, recurso, unidade)
-                       values (%s, %s, 2, %s, 'Requerimento', %s, 'Não se aplica', %s)""",
+        cur.execute("""insert into acervo_creg
+                       (num_processo, unidade, data_distribuicao, assunto, recurso, ordem)
+                       values (%s, %s, %s, 'Requerimento', 'Não se aplica', 2)""",
                     valores)
     except psycopg2.errors.UniqueViolation:
         return
     finally:
         cur.connection.rollback()
-    raise AssertionError('processos_sorteados aceitou a mesma distribuição duas vezes')
+    raise AssertionError('acervo_creg aceitou a mesma distribuição duas vezes')
 
 
 @teste
 def creg_novo_exige_numero_de_processo_com_15_digitos(cur):
-    """O acervo limpo mantém validada a regra aplicada às novas gravações."""
-    assert uma(cur, """select convalidated from pg_constraint
-                         where conrelid = 'public.processos_sorteados'::regclass
-                           and conname = 'processos_sorteados_num_processo_15_digitos'""") is True
+    """O acervo do Conselho recusa processo fora do padrão SEI.
+
+    Na tabela antiga isso era restrição acrescentada depois, NOT VALID até o
+    legado ser limpo. Em acervo_creg nasce no CREATE TABLE: não há legado a
+    tolerar, então vale para toda linha desde a primeira.
+    """
     try:
-        cur.execute("""insert into processos_sorteados
-                       (modo, data_hora, ordem, num_processo, assunto,
-                        data_distribuicao, recurso, unidade)
-                       values ('CREG', now(), 3, '1234', 'Requerimento',
-                               current_date, 'Não se aplica', 'CREG3')""")
+        cur.execute("""insert into acervo_creg
+                       (num_processo, unidade, data_distribuicao, assunto, recurso)
+                       values ('1234', 'CREG3', current_date,
+                               'Requerimento', 'Não se aplica')""")
     except psycopg2.errors.CheckViolation:
         return
     finally:
@@ -646,12 +663,78 @@ def creg_novo_exige_numero_de_processo_com_15_digitos(cur):
 
 
 @teste
-def migracao_preserva_creg_valido(cur):
-    """A limpeza remove só os dois fixtures inválidos, nunca o acervo real."""
-    assert uma(cur, """select modo, ordem, assunto, data_distribuicao, recurso, unidade
-                         from processos_sorteados
+def migracao_levou_o_sorteio_antigo_para_o_acervo(cur):
+    """A cadeia inteira que aposentou a tabela antiga, medida no resultado.
+
+    Os fixtures nascem em processos_sorteados (preparar_upgrade_da_migracao),
+    com a data do sorteio de 27/08/2026. Daí em diante, três migrações em
+    sequência: a 20260823165725 apaga os dois registros fora do padrão, a
+    20260828090000 copia o que sobrou para acervo_creg e a 20260902120000
+    derruba a tabela — só depois de conferir que nada ficou para trás.
+
+    Se qualquer um dos três elos falhar, é aqui que aparece: o processo válido
+    tem de estar no acervo, com os valores que tinha, e os dois inválidos não
+    podem ter atravessado a limpeza.
+    """
+    assert uma(cur, """select unidade, data_distribuicao, assunto, recurso,
+                              ordem, origem
+                         from acervo_creg
                         where num_processo = '202600029000777'""") == (
-        'CREG', 3, 'Requerimento', date(2026, 8, 20), 'Com recurso', 'CREG2')
+        'CREG2', date(2026, 8, 20), 'Requerimento', 'Com recurso', 3, 'sorteio')
+
+    assert uma(cur, """select count(*) from acervo_creg
+                        where num_processo in ('123421', '1234')""") == 0
+
+
+@teste
+def remocao_recusa_apagar_o_que_nao_foi_copiado(cur):
+    """A trava da migração de remoção é de verdade: sem cópia, ela não apaga.
+
+    Toda a segurança de derrubar uma tabela com dado dentro está nessa
+    conferência. Se ela estivesse escrita errada — condição invertida, join que
+    sempre casa — a migração passaria verde apagando o que ninguém teria como
+    recuperar, e nenhum outro teste perceberia: no banco da bateria a cópia
+    sempre deu certo.
+
+    Então aqui a tabela volta com uma linha que não está em acervo_creg, e a
+    migração roda de novo. Tem de parar, e a linha tem de continuar lá.
+    """
+    cur.execute("""create table public.processos_sorteados (
+                     id                bigint generated always as identity primary key,
+                     modo              text not null,
+                     data_hora         timestamptz not null,
+                     ordem             int,
+                     num_processo      text not null,
+                     assunto           text,
+                     data_distribuicao date not null,
+                     recurso           text,
+                     unidade           text not null)""")
+    cur.execute("""insert into public.processos_sorteados
+                   (modo, data_hora, ordem, num_processo, assunto,
+                    data_distribuicao, recurso, unidade)
+                   values ('CREG', now(), 1, '202600029000888', 'Requerimento',
+                           date '2026-08-20', 'Com recurso', 'CREG4')""")
+    cur.connection.commit()
+
+    try:
+        try:
+            rodar_arquivo(MIGRACAO_REMOCAO)
+        except psycopg2.errors.RaiseException as erro:
+            assert 'acervo_creg' in str(erro), erro
+        else:
+            raise AssertionError('a migração apagou a tabela sem conferir a cópia')
+
+        sobrou = uma(cur, """select count(*) from public.processos_sorteados
+                              where num_processo = '202600029000888'""")
+        assert sobrou == 1, 'a linha sem cópia devia ter sobrevivido'
+    finally:
+        # A transação de cur segura um lock sobre a tabela; o drop vem de outra
+        # conexão e ficaria esperando por ela para sempre. Fechar antes não é
+        # zelo, é o que impede a bateria de travar aqui.
+        cur.connection.rollback()
+        PG.executar('drop table if exists public.processos_sorteados')
+
+    assert uma(cur, "select to_regclass('public.processos_sorteados')") is None
 
 
 @teste
@@ -1308,9 +1391,8 @@ def painel_traduz_cadeira_e_deixa_o_resto_intacto(cur):
 def creg_grava_no_proprio_acervo(cur):
     """Desde 27/08/2026 o sorteio do Conselho vai para acervo_creg.
 
-    processos_sorteados continua no schema como legado (ver o comentário lá),
-    mas nada escreve nela: o front aponta para o acervo, e é de lá que os
-    julgados do CREG saem.
+    É a única tabela em que o CREG grava: a antiga saiu do schema, o front
+    aponta para o acervo e é de lá que os julgados do Conselho saem.
     """
     cur.execute("""insert into acervo_creg
                    (num_processo, unidade, data_distribuicao, assunto, recurso)
@@ -1452,8 +1534,44 @@ def migracoes_estao_todas_cobertas(cur):
     assert arquivos - aplicadas == MIGRACOES_SUPERADAS, (
         'migração fora da bateria: ' + ', '.join(sorted(arquivos - aplicadas)))
     assert MIGRACOES_SUPERADAS <= arquivos, 'MIGRACOES_SUPERADAS cita arquivo que não existe'
-    for constante in (MIGRACAO_CADEIRAS, MIGRACAO_HARDENING, MIGRACAO_INTERESSADO):
+    for constante in (MIGRACAO_CADEIRAS, MIGRACAO_HARDENING, MIGRACAO_INTERESSADO,
+                      MIGRACAO_REMOCAO):
         assert constante.name in aplicadas, constante.name
+
+
+@teste
+def schema_declara_toda_funcao_que_existe_no_banco(cur):
+    """O schema.sql tem de conhecer toda função que o banco tem.
+
+    migracoes_reproduzem_o_schema pega a função que o schema MUDA, mas não a
+    que ele esquece: se uma migração cria uma função que o schema.sql nunca
+    menciona, reaplicar o schema não mexe nela, `antes` e `depois` ficam iguais
+    e a comparação passa verde.
+
+    Foi por esse buraco que historico_sorteios, processos_sorteio e
+    historico_marco viveram em produção sem estar no repositório — aplicadas
+    direto no banco, sem commit, e nenhum teste tinha como notar. A conta aqui
+    é a inversa: o conjunto de funções do banco tem de ser exatamente o que o
+    arquivo declara, nem mais nem menos.
+
+    Roda ANTES de migracoes_reproduzem_o_schema de propósito: neste ponto o
+    banco veio só das migrações, que é o estado que produção tem.
+    """
+    fonte = (RAIZ / 'sql' / 'schema.sql').read_text(encoding='utf-8')
+    declaradas = set(re.findall(
+        r'create\s+(?:or\s+replace\s+)?function\s+public\.(\w+)', fonte))
+
+    cur.execute("""select distinct p.proname
+                     from pg_proc p
+                     join pg_namespace n on n.oid = p.pronamespace
+                    where n.nspname = 'public' and p.prokind = 'f'""")
+    no_banco = {nome for (nome,) in cur.fetchall()}
+
+    assert no_banco == declaradas, (
+        'no banco e fora do schema.sql: '
+        + (', '.join(sorted(no_banco - declaradas)) or '—')
+        + ' / no schema.sql e fora do banco: '
+        + (', '.join(sorted(declaradas - no_banco)) or '—'))
 
 
 @teste
@@ -1509,9 +1627,32 @@ def migracoes_a_aplicar():
 def preparar_upgrade_da_migracao():
     """Volta só os deltas desta migração ao estado do schema no HEAD."""
     PG.executar("""
-        alter table public.processos_sorteados
-          drop constraint processos_sorteados_num_processo_15_digitos;
-        drop index public.ux_processos_sorteados_distribuicao;
+        -- A tabela do sorteio antigo do Conselho, recriada no formato que ela
+        -- tinha antes desta migração: sem a restrição de 15 dígitos, sem o
+        -- índice de distribuição única e sem a coluna interessado, que só
+        -- chegaria em 20260827160000. O schema.sql não a cria mais — quem a
+        -- derrubou foi a migração 20260902120000 —, então é aqui que ela
+        -- volta, e só para que as migrações que mexem nela tenham em que
+        -- mexer. No fim da bateria ela é derrubada de novo, pela migração de
+        -- verdade.
+        create table public.processos_sorteados (
+          id                bigint generated always as identity primary key,
+          criado_em         timestamptz not null default now(),
+          modo              text        not null check (modo = 'CREG'),
+          data_hora         timestamptz not null,
+          ordem             int         not null,
+          num_processo      text        not null,
+          assunto           text        not null,
+          data_distribuicao date        not null,
+          recurso           text        not null,
+          unidade           text        not null
+        );
+        create index idx_processos_sorteados_modo_data
+          on public.processos_sorteados (modo, data_hora desc);
+        alter table public.processos_sorteados enable row level security;
+        create policy "usuario autenticado pode inserir"
+          on public.processos_sorteados for insert to authenticated with check (true);
+
         delete from public.pautas_cj where url = 'marco:inicio-da-serie';
 
         create or replace function public.julgados_cj_derivar_do_acervo()
@@ -1622,15 +1763,19 @@ def preparar_upgrade_da_migracao():
         grant execute on function public.registrar_votos(jsonb)
           to anon, service_role;
 
+        -- data_hora dentro de 27/08/2026 de propósito: é a janela que a
+        -- migração 20260828090000 copia para acervo_creg. Com now() a cópia
+        -- não alcançava linha nenhuma e passava verde sem ter feito nada —
+        -- migracao_levou_o_sorteio_antigo_para_o_acervo mede o resultado dela.
         insert into public.processos_sorteados
           (modo, data_hora, ordem, num_processo, assunto,
            data_distribuicao, recurso, unidade)
         values
-          ('CREG', now(), 1, '123421', 'Requerimento',
+          ('CREG', timestamptz '2026-08-27 11:07:26-03', 1, '123421', 'Requerimento',
            date '2026-08-20', 'Com recurso', 'CREG2'),
-          ('CREG', now(), 2, '1234', 'Requerimento',
+          ('CREG', timestamptz '2026-08-27 11:07:26-03', 2, '1234', 'Requerimento',
            date '2026-08-20', 'Sem recurso', 'CREG3'),
-          ('CREG', now(), 3, '202600029000777', 'Requerimento',
+          ('CREG', timestamptz '2026-08-27 11:07:26-03', 3, '202600029000777', 'Requerimento',
            date '2026-08-20', 'Com recurso', 'CREG2');
     """)
 


### PR DESCRIPTION
## O que muda

Remove `processos_sorteados`, a tabela do sorteio antigo do Conselho Regulador, e consolida `acervo_creg` como fonte única do acervo do CREG.

Ela era medida provisória: até 27/08/2026 o CREG não tinha o desenho da Câmara e o sorteador gravava numa tabela solta — sem acervo, sem julgados e sem vínculo com nada. Desde a migração `20260827150000` o Conselho tem o par completo, e o `index.js` grava em `acervo_creg`.

## Conferência feita antes de apagar

Contra o banco de produção:

| conferência | resultado |
|---|---|
| linhas em `processos_sorteados` | 81 |
| linhas sem correspondente exato em `acervo_creg` | **0** |
| FK, view, trigger ou função dependendo da tabela | **nenhuma** |

A migração de remoção **reconfere a cópia e aborta** em vez de apagar, se faltar alguma linha. É repetível: quando a tabela já não existe, não há o que conferir nem o que derrubar.

## Alterações

- **Nova migração** `20260902120000_remover_processos_sorteados.sql`.
- **`schema.sql`** — saem a tabela, os índices, a restrição de 15 dígitos, o RLS, a política, os grants e a sequência.
- **`verificacao_cj.sql`** — saem as três conferências que liam a tabela. As equivalentes já existem no `verificacao_creg.sql` sobre `acervo_creg`.
- **Docs** (`README`, `FLUXO-CJ`, `FLUXO-CREG`) atualizados.

Ficam intactos, de propósito, o `docs/ALTERACOES-PRE-PRODUCAO-2026-08-23.md` e as quatro migrações antigas que citam a tabela: são registro histórico, e reescrevê-los falsearia o que aconteceu.

## Testes

As duas regras do CREG que só existiam na tabela antiga passam a exercitar `acervo_creg`, que já as carrega (`acervo_creg_distribuicao_unica` e o check de 15 dígitos).

Duas lacunas que estavam passando verde e agora têm cobertura de verdade:

- **As fixtures nasciam com `now()`**, fora da janela de 27/08 que a migração de cópia recorta — ela copiava zero linhas e passava sem fazer nada. Com a data corrigida, `migracao_levou_o_sorteio_antigo_para_o_acervo` mede a cadeia inteira: limpeza → cópia → remoção.
- **A trava da migração de remoção não era exercitada.** `remocao_recusa_apagar_o_que_nao_foi_copiado` recria a tabela com uma linha sem cópia e exige que a migração pare.

## Também neste PR: a divergência entre produção e repositório

Encontrada durante o trabalho, anterior a ele.

Produção tinha **duas migrações aplicadas direto no banco em 01/09 e nunca commitadas** (`historico_sorteios`, `historico_sorteios_marco_unico`), trazendo três funções que não existiam no repositório: `historico_marco`, `historico_sorteios(text)` e `processos_sorteio(text, date, timestamptz)`. Nenhuma lia a tabela removida.

As duas migrações foram versionadas com o SQL exatamente como aplicado, e o bloco correspondente entrou no `schema.sql`. **Conferido por hash contra produção:** as 13 funções batem byte a byte.

### A causa

O `migracoes_reproduzem_o_schema` é unidirecional: ele roda o `schema.sql` por cima e compara antes/depois. Função que as migrações criam e o schema **nunca menciona** não é tocada pela reaplicação — `antes` e `depois` ficam iguais, e passa verde.

O novo `schema_declara_toda_funcao_que_existe_no_banco` faz a conta inversa: o conjunto de funções do banco tem de ser exatamente o que o arquivo declara. Verificado que não passa por vacuidade — removendo o bloco do `schema.sql`, ele acusa precisamente as três funções.

## Estado da suíte

`151/151` testes de banco e sincronização, `53` de frontend, `2` suítes JS. Sem alteração nos assets minificados.

## Pendências para decisão

1. **`ping()` também diverge de produção**, só na formatação do corpo (`select 'pong'` em uma linha lá, em três aqui). Comportamento idêntico — a migração `20260827104200` só mexeu no `search_path`, nunca recriou o corpo. Não normalizei para não criar uma migração só de espaçamento.
2. **O front-end do histórico não existe no repositório.** As migrações citam `historico-cj.html` e `historico-creg.html`, e nenhuma das duas está aqui, nem JS que chame essas funções. Há trabalho de front-end que aparentemente nunca foi commitado.

## Produção

A remoção **já foi aplicada** (versão `20260902105750`), a pedido. Sem resíduo: tabela, sequência, política, grants, índices e restrições zerados. `acervo_creg` intacta (3.181 linhas, 81 do sorteio), painéis de CJ e CREG respondendo, e as cinco conferências de ERRO do CREG em zero.

Closed #26 
