### PR TITLE
fix(actions): sincronizar duas vezes ao dia, antes de 12:00 e 17:00

### DIFF
--- a/.github/workflows/sincronizar-julgados.yml
+++ b/.github/workflows/sincronizar-julgados.yml
@@ -9,10 +9,10 @@
 # Roda os DOIS colegiados na mesma passagem, um de cada vez. A Câmara de
 # Julgamento reúne às quintas e o Conselho Regulador não tem dia fixo (em 2026
 # houve sessão em quarta, quinta e sexta), e nenhum dos dois anuncia a hora em
-# que a pauta vai ao ar — por isso a busca é de hora em hora durante o
-# expediente, e não uma rodada semanal: uma pauta publicada na terça à tarde
-# entrava no site só na sexta seguinte. Cada colegiado tem a sua página na AGR
-# e o seu par de tabelas — ver COLEGIADOS em sincronizacao/sincronizar.py.
+# que a pauta vai ao ar — por isso a busca é diária, e não uma rodada semanal:
+# uma pauta publicada na terça à tarde entrava no site só na sexta seguinte.
+# Cada colegiado tem a sua página na AGR e o seu par de tabelas — ver
+# COLEGIADOS em sincronizacao/sincronizar.py.
 #
 # Repetir a busca é barato e não duplica nada: a rodada que não acha pauta nova
 # é uma consulta à listagem de cada colegiado, e o que já foi sincronizado fica
@@ -31,12 +31,22 @@ name: Sincronizar Julgados
 
 on:
   schedule:
-    # De hora em hora, das 07:00 às 20:00 em Goiás (UTC−3, sem horário de
-    # verão), todos os dias. A janela cobre o expediente da AGR com folga dos
-    # dois lados; o que sair fora dela espera a primeira rodada da manhã. O
-    # GitHub atrasa agendamentos em horário de pico e não garante o minuto
-    # exato — por isso a janela, e não um horário só.
-    - cron: '0 10-23 * * *'
+    # Duas atualizações por dia, cada uma antes de uma consulta ao site da
+    # AGR: a do meio-dia e a do fim do expediente, 12:00 e 17:00 no horário de
+    # Goiás. O cron do Actions é sempre UTC e não aceita fuso; Goiás é UTC−3 o
+    # ano todo (o Brasil acabou com o horário de verão em 2019), então some
+    # três horas para ler os horários abaixo.
+    #
+    # Cada janela dispara DUAS vezes, 40 e 10 minutos antes do horário-alvo,
+    # porque `on: schedule` é best-effort: o GitHub descarta rodadas em pico e
+    # atrasa as que sobram — neste repositório, de 11 a 55 minutos, com 10 de
+    # 14 rodadas diárias descartadas antes desta mudança. Antecipar dá margem
+    # para a pauta estar no ar na hora da consulta, e a segunda tentativa cobre
+    # a primeira quando ela é descartada; quando as duas rodam, a segunda não
+    # acha pauta nova e não grava nada. Os minutos são quebrados de propósito:
+    # o `:00` é o mais disputado de todos.
+    - cron: '20,50 14 * * *'   # 11:20 e 11:50 em Goiás — consulta das 12:00
+    - cron: '20,50 19 * * *'   # 16:20 e 16:50 em Goiás — consulta das 17:00
   workflow_dispatch:
     inputs:
       colegiado:


### PR DESCRIPTION
## Contexto

O job `Sincronizar Julgados` estava agendado de hora em hora (`0 10-23 * * *`), mas o `on: schedule` do GitHub Actions é best-effort: em pico ele descarta rodadas e atrasa as que sobram. Ontem, das 14 rodadas previstas, só 4 executaram, com atraso de 11 a 55 minutos.

## Mudança

Duas janelas diárias, cada uma antes de uma consulta ao site da AGR (12:00 e 17:00, horário de Goiás — UTC−3 o ano todo, sem horário de verão):

```yaml
- cron: '20,50 14 * * *'   # 11:20 e 11:50 em Goiás — consulta das 12:00
- cron: '20,50 19 * * *'   # 16:20 e 16:50 em Goiás — consulta das 17:00
```

Cada janela dispara duas vezes (40 e 10 minutos antes do horário-alvo, em minutos fora do `:00` mais disputado):
- a antecedência dá margem para a pauta estar publicada a tempo da consulta;
- a segunda tentativa cobre a primeira quando ela é descartada;
- quando as duas rodam, a segunda não encontra pauta nova e não grava nada (idempotente — ver `pautas_pendentes` em `sincronizacao/sincronizar.py`).

## Sobre a garantia de horário

Nenhum ajuste de cron torna o `on: schedule` exato — é uma limitação do GitHub, não deste workflow. O que esta mudança faz é reduzir a exposição ao atraso/descarte, não eliminá-la. No pior caso (as duas tentativas de uma janela descartadas), a atualização chega atrasada na janela seguinte, não perdida: a elegibilidade das pautas usa um marco fixo (`corte` em `pautas_pendentes`), então toda execução reconsidera o histórico completo e recupera o que ficou pendente.

Se o horário exato vier a ser um requisito, o caminho é um gatilho externo (`workflow_dispatch` via API, por exemplo a partir de `pg_cron` no Supabase que o projeto já usa) — fora do escopo desta mudança.

## Verificação

- YAML validado com `js-yaml` (gatilhos `schedule`/`workflow_dispatch` e `concurrency` intactos).
- Conversão UTC → Goiás conferida via tzdata do ICU (Node), com offset `GMT-03:00` constante nos 12 meses de 2026.

Closed #31 